### PR TITLE
Fix Travis script

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,6 +4,6 @@ insert_final_newline = true
 charset = utf-8
 indent_style = tab
 
-[*.yml,.travis.yml]
+[{*.yml,.travis.yml,package.json}]
 idennt_size = 2
 indent_style = space

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
 cache:
   directories:
     - "node_modules"
+install: yarn --production=false # install devDepdendencies
 script: yarn run build
 deploy:
   provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
 cache:
   directories:
     - "node_modules"
+script: yarn run build
 deploy:
   provider: pages
   skip_cleanup: true


### PR DESCRIPTION
Travis was attempting to run `npm run test`, which doesn't exist. It now runs `yarn run build`.

<small>This PR also includes a fix to the .editorconfig file, which was misconfigured to use tabs in .travis.yml and package.json.</small>